### PR TITLE
update sequelize&sequelize-typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "mz-modules": "^2.1.0",
     "reflect-metadata": "^0.1.12",
-    "sequelize": "^4.38.0",
-    "sequelize-typescript": "^0.6.6",
+    "sequelize": "^5.21.5",
+    "sequelize-typescript": "^1.1.0",
     "typescript": "^3.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
不升级的话，无法支持 BelongsTo 等关联装饰器，启动报错